### PR TITLE
The fallback GRPC port was set to 0 by accident. Now it is set to 14317.

### DIFF
--- a/src/Uptrace.OpenTelemetry/UptraceOptions.cs
+++ b/src/Uptrace.OpenTelemetry/UptraceOptions.cs
@@ -32,10 +32,12 @@ namespace Uptrace.OpenTelemetry
             }
             else
             {
-                var grpcPort = 14317;
 
                 var query = System.Web.HttpUtility.ParseQueryString(uri.Query);
-                Int32.TryParse(query["grpc"], out grpcPort);
+                if (!Int32.TryParse(query["grpc"], out var grpcPort))
+                {
+                    grpcPort = 14317;
+                }
 
                 this.OtlpGrpcEndpoint =
                     new UriBuilder


### PR DESCRIPTION
The fallback GRPC port was set to 0 by accident. Now it is set to 14317.
Fixed #32 